### PR TITLE
fix grid_map dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,9 +15,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
-  <depend>grid_map_msgs</depend>
-  <depend>grid_map_core</depend>
-  <depend>grid_map_ros</depend>
+  <depend>grid_map</depend>
   <depend>pcl_conversions</depend>
   <depend>eigen</depend>
   <depend>libpcl-all-dev</depend>

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>grid_map</depend>
+  <depend>grid_map_ros</depend>
   <depend>pcl_conversions</depend>
   <depend>eigen</depend>
   <depend>libpcl-all-dev</depend>


### PR DESCRIPTION
Fix for missing grid_map rviz plugin when ruunning ros2 launch navi_sim with_planner.launch.py